### PR TITLE
Force encoding of page request to utf-8 to prevent character managling

### DIFF
--- a/tswift.py
+++ b/tswift.py
@@ -44,6 +44,9 @@ class Song(object):
     def load(self):
         """Load the lyrics from MetroLyrics."""
         page = requests.get(self._url)
+        # Forces utf-8 to prevent character mangling
+        page.encoding = 'utf-8'
+
         tree = html.fromstring(page.text)
         lyric_div = tree.get_element_by_id('lyrics-body-text')
         verses = [c.text_content() for c in lyric_div]


### PR DESCRIPTION
While attempting to get lyrics using the library I ran into problems with accented characters returned in the lyrics. For example, the song _Hasta la Raíz_ by Natalia Lafourcade was returning misrepresented accented characters.

Merging in this change would support more songs.
